### PR TITLE
minor doc comment fix in lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 //!          .as_any()
 //!          .downcast_ref::<Goodbye>(){}
 //!     ....
-//!
+//!```
 //!
 //! Encoding RTCP packets:
 //!```nobuild
@@ -39,6 +39,7 @@
 //!
 //!     let pli_data = pkt.marshal().unwrap();
 //!     // ...
+//!```
 
 pub mod compound_packet;
 mod error;


### PR DESCRIPTION
As seen in https://docs.rs/rtcp/0.6.4/rtcp/index.html
The decode/encode code samples both do not have a closing set of backticks. This adds them.