### PR TITLE
update deps + loosen some requirements

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -10,32 +10,47 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-    name: Build and test
+  check_and_test:
+    name: Check and test
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        toolchain:
+          - 1.56.1 # min supported version (https://github.com/webrtc-rs/webrtc/#toolchain)
+          - stable
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - name: Build
-        run: cargo build --verbose
-      - name: Run tests
-        run: cargo test --verbose
-
-  rustfmt_and_clippy:
-    name: Check rustfmt style && run clippy
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.55.0
+          toolchain: ${{ matrix.toolchain }}
+          profile: minimal
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  rustfmt_and_clippy:
+    name: Check rustfmt style and run clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
           profile: minimal
           components: clippy, rustfmt
           override: true
       - name: Cache cargo registry
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
@@ -43,8 +58,28 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
+          args: -- -D warnings
       - name: Check formating
         uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
+
+  minimal_versions:
+    name: Compile and test with minimal versions
+    strategy:
+      matrix:
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: nightly
+            override: true
+      - uses: taiki-e/install-action@cargo-hack
+      - uses: taiki-e/install-action@cargo-minimal-versions
+      - run: cargo minimal-versions check --workspace --all-features --ignore-private -v
+      - run: cargo minimal-versions build --workspace --all-features --ignore-private -v
+      - run: cargo minimal-versions test --workspace --all-features -v

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://webrtc.rs"
 repository = "https://github.com/webrtc-rs/rtcp"
 
 [dependencies]
-util = { package = "webrtc-util", version = "0.5.3", default-features = false, features = ["marshal"] }
+util = { package = "webrtc-util", version = "0.5.4", default-features = false, features = ["marshal"] }
 bytes = "1"
 thiserror = "1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,9 @@ repository = "https://github.com/webrtc-rs/rtcp"
 
 [dependencies]
 util = { package = "webrtc-util", version = "0.5.3", default-features = false, features = ["marshal"] }
-bytes = "1.1.0"
-thiserror = "1.0.30"
+bytes = "1"
+thiserror = "1.0"
 
 [dev-dependencies]
-tokio = { version = "1.15.0", features = ["sync"] }
-tokio-test = "0.4.2"
+tokio = { version = "1.19", features = ["sync"] }
+tokio-test = "0.4.0" # must match the min version of the `tokio` crate above

--- a/src/compound_packet/compound_packet_test.rs
+++ b/src/compound_packet/compound_packet_test.rs
@@ -81,7 +81,8 @@ fn test_bad_compound() {
 
     if compound.0[1]
         .as_any()
-        .downcast_ref::<PictureLossIndication>().is_none()
+        .downcast_ref::<PictureLossIndication>()
+        .is_none()
     {
         panic!("Unmarshal(badcompound), want PictureLossIndication")
     }

--- a/src/compound_packet/compound_packet_test.rs
+++ b/src/compound_packet/compound_packet_test.rs
@@ -75,13 +75,13 @@ fn test_bad_compound() {
         compound_len, 2
     );
 
-    if let None = compound.0[0].as_any().downcast_ref::<Goodbye>() {
+    if compound.0[0].as_any().downcast_ref::<Goodbye>().is_none() {
         panic!("Unmarshal(badcompound), want Goodbye")
     }
 
-    if let None = compound.0[1]
+    if compound.0[1]
         .as_any()
-        .downcast_ref::<PictureLossIndication>()
+        .downcast_ref::<PictureLossIndication>().is_none()
     {
         panic!("Unmarshal(badcompound), want PictureLossIndication")
     }
@@ -311,7 +311,7 @@ fn test_compound_packet_roundtrip() {
                     name, got, err
                 );
             } else {
-                assert!(false, "want error in test {}", name);
+                panic!("want error in test {}", name);
             }
             continue;
         } else {

--- a/src/extended_report/dlrr.rs
+++ b/src/extended_report/dlrr.rs
@@ -3,7 +3,7 @@ use super::*;
 const DLRR_REPORT_LENGTH: u16 = 12;
 
 /// DLRRReport encodes a single report inside a DLRRReportBlock.
-#[derive(Debug, Default, PartialEq, Clone)]
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
 pub struct DLRRReport {
     pub ssrc: u32,
     pub last_rr: u32,
@@ -34,7 +34,7 @@ impl fmt::Display for DLRRReport {
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ block
 /// :                               ...                             :   2
 /// +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
-#[derive(Debug, Default, PartialEq, Clone)]
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
 pub struct DLRRReportBlock {
     pub reports: Vec<DLRRReport>,
 }

--- a/src/extended_report/mod.rs
+++ b/src/extended_report/mod.rs
@@ -32,7 +32,7 @@ const XR_HEADER_LENGTH: usize = 4;
 
 /// BlockType specifies the type of report in a report block
 /// Extended Report block types from RFC 3611.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum BlockType {
     Unknown = 0,
     LossRLE = 1,               // RFC 3611, section 4.1
@@ -93,7 +93,7 @@ pub type TypeSpecificField = u8;
 /// shouldn't need to access this. For locally-constructed report
 /// blocks, these values will not be accurate until the corresponding
 /// packet is marshaled.
-#[derive(Debug, Default, PartialEq, Clone)]
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
 pub struct XRHeader {
     pub block_type: BlockType,
     pub type_specific: TypeSpecificField,

--- a/src/extended_report/prt.rs
+++ b/src/extended_report/prt.rs
@@ -22,7 +22,7 @@ const PRT_REPORT_BLOCK_MIN_LENGTH: u16 = 8;
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// |       Receipt time of packet (end_seq - 1) mod 65536          |
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-#[derive(Debug, Default, PartialEq, Clone)]
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
 pub struct PacketReceiptTimesReportBlock {
     //not included in marshal/unmarshal
     pub t: u8,

--- a/src/extended_report/rle.rs
+++ b/src/extended_report/rle.rs
@@ -3,7 +3,7 @@ use super::*;
 const RLE_REPORT_BLOCK_MIN_LENGTH: u16 = 8;
 
 /// ChunkType enumerates the three kinds of chunks described in RFC 3611 section 4.1.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ChunkType {
     RunLength = 0,
     BitVector = 1,
@@ -36,7 +36,7 @@ pub enum ChunkType {
 ///  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 ///  |0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0|
 ///  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-#[derive(Debug, Default, PartialEq, Clone)]
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
 pub struct Chunk(pub u16);
 
 impl fmt::Display for Chunk {
@@ -102,7 +102,7 @@ impl Chunk {
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// |          chunk n-1            |             chunk n           |
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-#[derive(Debug, Default, PartialEq, Clone)]
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
 pub struct RLEReportBlock {
     //not included in marshal/unmarshal
     pub is_loss_rle: bool,

--- a/src/extended_report/rrt.rs
+++ b/src/extended_report/rrt.rs
@@ -14,7 +14,7 @@ const RRT_REPORT_BLOCK_LENGTH: u16 = 8;
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// |             NTP timestamp, least significant word             |
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-#[derive(Debug, Default, PartialEq, Clone)]
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
 pub struct ReceiverReferenceTimeReportBlock {
     pub ntp_timestamp: u64,
 }

--- a/src/extended_report/ssr.rs
+++ b/src/extended_report/ssr.rs
@@ -28,7 +28,7 @@ const SSR_REPORT_BLOCK_LENGTH: u16 = 4 + 2 * 2 + 4 * 6 + 4;
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// | min_ttl_or_hl | max_ttl_or_hl |mean_ttl_or_hl | dev_ttl_or_hl |
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-#[derive(Debug, Default, PartialEq, Clone)]
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
 pub struct StatisticsSummaryReportBlock {
     //not included in marshal/unmarshal
     pub loss_reports: bool,
@@ -60,7 +60,7 @@ impl fmt::Display for StatisticsSummaryReportBlock {
 
 /// TTLorHopLimitType encodes values for the ToH field in
 /// a StatisticsSummaryReportBlock
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum TTLorHopLimitType {
     Missing = 0,
     IPv4 = 1,

--- a/src/extended_report/unknown.rs
+++ b/src/extended_report/unknown.rs
@@ -2,7 +2,7 @@ use super::*;
 
 /// UnknownReportBlock is used to store bytes for any report block
 /// that has an unknown Report Block Type.
-#[derive(Debug, Default, PartialEq, Clone)]
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
 pub struct UnknownReportBlock {
     pub bytes: Bytes,
 }

--- a/src/extended_report/vm.rs
+++ b/src/extended_report/vm.rs
@@ -26,7 +26,7 @@ const VM_REPORT_BLOCK_LENGTH: u16 = 4 + 4 + 2 * 4 + 10 + 2 * 3;
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// |          JB maximum           |          JB abs max           |
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-#[derive(Debug, Default, PartialEq, Clone)]
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
 pub struct VoIPMetricsReportBlock {
     pub ssrc: u32,
     pub loss_rate: u8,

--- a/src/goodbye/mod.rs
+++ b/src/goodbye/mod.rs
@@ -11,7 +11,7 @@ use std::fmt;
 type Result<T> = std::result::Result<T, util::Error>;
 
 /// The Goodbye packet indicates that one or more sources are no longer active.
-#[derive(Debug, PartialEq, Default, Clone)]
+#[derive(Debug, PartialEq, Eq, Default, Clone)]
 pub struct Goodbye {
     /// The SSRC/CSRC identifiers that are no longer active
     pub sources: Vec<u32>,

--- a/src/header.rs
+++ b/src/header.rs
@@ -5,7 +5,7 @@ use bytes::{Buf, BufMut};
 
 /// PacketType specifies the type of an RTCP packet
 /// RTCP packet types registered with IANA. See: https://www.iana.org/assignments/rtp-parameters/rtp-parameters.xhtml#rtp-parameters-4
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(u8)]
 pub enum PacketType {
     Unsupported = 0,
@@ -88,7 +88,7 @@ pub const SSRC_LENGTH: usize = 4;
 pub const SDES_MAX_OCTET_COUNT: usize = (1 << 8) - 1;
 
 /// A Header is the common header shared by all RTCP packets
-#[derive(Debug, PartialEq, Default, Clone)]
+#[derive(Debug, PartialEq, Eq, Default, Clone)]
 pub struct Header {
     /// If the padding bit is set, this individual RTCP packet contains
     /// some additional padding octets at the end which are not part of

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -212,7 +212,7 @@ mod test {
             let want = Error::InvalidHeader;
             assert_eq!(want, got, "Unmarshal(nil) err = {}, want {}", got, want);
         } else {
-            assert!(false, "want error");
+            panic!("want error");
         }
 
         Ok(())
@@ -235,7 +235,7 @@ mod test {
                 got, want
             );
         } else {
-            assert!(false, "want error");
+            panic!("want error");
         }
 
         Ok(())

--- a/src/payload_feedbacks/full_intra_request/mod.rs
+++ b/src/payload_feedbacks/full_intra_request/mod.rs
@@ -11,7 +11,7 @@ use std::fmt;
 type Result<T> = std::result::Result<T, util::Error>;
 
 /// A FIREntry is a (ssrc, seqno) pair, as carried by FullIntraRequest.
-#[derive(Debug, PartialEq, Default, Clone)]
+#[derive(Debug, PartialEq, Eq, Default, Clone)]
 pub struct FirEntry {
     pub ssrc: u32,
     pub sequence_number: u8,
@@ -20,7 +20,7 @@ pub struct FirEntry {
 /// The FullIntraRequest packet is used to reliably request an Intra frame
 /// in a video stream.  See RFC 5104 Section 3.5.1.  This is not for loss
 /// recovery, which should use PictureLossIndication (PLI) instead.
-#[derive(Debug, PartialEq, Default, Clone)]
+#[derive(Debug, PartialEq, Eq, Default, Clone)]
 pub struct FullIntraRequest {
     pub sender_ssrc: u32,
     pub media_ssrc: u32,

--- a/src/payload_feedbacks/picture_loss_indication/mod.rs
+++ b/src/payload_feedbacks/picture_loss_indication/mod.rs
@@ -13,7 +13,7 @@ type Result<T> = std::result::Result<T, util::Error>;
 const PLI_LENGTH: usize = 2;
 
 /// The PictureLossIndication packet informs the encoder about the loss of an undefined amount of coded video data belonging to one or more pictures
-#[derive(Debug, PartialEq, Default, Clone)]
+#[derive(Debug, PartialEq, Eq, Default, Clone)]
 pub struct PictureLossIndication {
     /// SSRC of sender
     pub sender_ssrc: u32,

--- a/src/payload_feedbacks/receiver_estimated_maximum_bitrate/receiver_estimated_maximum_bitrate_test.rs
+++ b/src/payload_feedbacks/receiver_estimated_maximum_bitrate/receiver_estimated_maximum_bitrate_test.rs
@@ -103,7 +103,7 @@ fn test_receiver_estimated_maximum_bitrate_overflow() {
     // exp = 63
     // bitrate = 0xFFFFC00000000000
 
-    let mut buf = output.clone();
+    let mut buf = output;
     let packet = ReceiverEstimatedMaximumBitrate::unmarshal(&mut buf).unwrap();
     assert_eq!(f32::from_bits(0x67FFFFC0), packet.bitrate);
 

--- a/src/payload_feedbacks/slice_loss_indication/mod.rs
+++ b/src/payload_feedbacks/slice_loss_indication/mod.rs
@@ -15,7 +15,7 @@ const SLI_OFFSET: usize = 8;
 
 /// SLIEntry represents a single entry to the SLI packet's
 /// list of lost slices.
-#[derive(Debug, PartialEq, Default, Clone)]
+#[derive(Debug, PartialEq, Eq, Default, Clone)]
 pub struct SliEntry {
     /// ID of first lost slice
     pub first: u16,
@@ -26,7 +26,7 @@ pub struct SliEntry {
 }
 
 /// The SliceLossIndication packet informs the encoder about the loss of a picture slice
-#[derive(Debug, PartialEq, Default, Clone)]
+#[derive(Debug, PartialEq, Eq, Default, Clone)]
 pub struct SliceLossIndication {
     /// SSRC of sender
     pub sender_ssrc: u32,

--- a/src/raw_packet.rs
+++ b/src/raw_packet.rs
@@ -8,7 +8,7 @@ use std::fmt;
 
 /// RawPacket represents an unparsed RTCP packet. It's returned by Unmarshal when
 /// a packet with an unknown type is encountered.
-#[derive(Debug, PartialEq, Default, Clone)]
+#[derive(Debug, PartialEq, Eq, Default, Clone)]
 pub struct RawPacket(pub Bytes);
 
 impl fmt::Display for RawPacket {

--- a/src/receiver_report/mod.rs
+++ b/src/receiver_report/mod.rs
@@ -14,7 +14,7 @@ pub(super) const RR_SSRC_OFFSET: usize = HEADER_LENGTH;
 pub(super) const RR_REPORT_OFFSET: usize = RR_SSRC_OFFSET + SSRC_LENGTH;
 
 /// A ReceiverReport (RR) packet provides reception quality feedback for an RTP stream
-#[derive(Debug, PartialEq, Default, Clone)]
+#[derive(Debug, PartialEq, Eq, Default, Clone)]
 pub struct ReceiverReport {
     /// The synchronization source identifier for the originator of this RR packet.
     pub ssrc: u32,

--- a/src/reception_report.rs
+++ b/src/reception_report.rs
@@ -15,7 +15,7 @@ pub(crate) const DELAY_OFFSET: usize = 20;
 
 /// A ReceptionReport block conveys statistics on the reception of RTP packets
 /// from a single synchronization source.
-#[derive(Debug, PartialEq, Default, Clone)]
+#[derive(Debug, PartialEq, Eq, Default, Clone)]
 pub struct ReceptionReport {
     /// The SSRC identifier of the source to which the information in this
     /// reception report block pertains.

--- a/src/sender_report/mod.rs
+++ b/src/sender_report/mod.rs
@@ -24,7 +24,7 @@ pub(crate) const SR_OCTET_COUNT_OFFSET: usize = SR_PACKET_COUNT_OFFSET + SR_PACK
 pub(crate) const SR_OCTET_COUNT_LENGTH: usize = 4;
 
 /// A SenderReport (SR) packet provides reception quality feedback for an RTP stream
-#[derive(Debug, PartialEq, Default, Clone)]
+#[derive(Debug, PartialEq, Eq, Default, Clone)]
 pub struct SenderReport {
     /// The synchronization source identifier for the originator of this SR packet.
     pub ssrc: u32,

--- a/src/source_description/mod.rs
+++ b/src/source_description/mod.rs
@@ -20,7 +20,7 @@ const SDES_TEXT_OFFSET: usize = 2;
 
 /// SDESType is the item type used in the RTCP SDES control packet.
 /// RTP SDES item types registered with IANA. See: https://www.iana.org/assignments/rtp-parameters/rtp-parameters.xhtml#rtp-parameters-5
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(u8)]
 pub enum SdesType {
     SdesEnd = 0,      // end of SDES list                RFC 3550, 6.5
@@ -74,7 +74,7 @@ impl From<u8> for SdesType {
 }
 
 /// A SourceDescriptionChunk contains items describing a single RTP source
-#[derive(Debug, PartialEq, Default, Clone)]
+#[derive(Debug, PartialEq, Eq, Default, Clone)]
 pub struct SourceDescriptionChunk {
     /// The source (ssrc) or contributing source (csrc) identifier this packet describes
     pub source: u32,
@@ -176,7 +176,7 @@ impl Unmarshal for SourceDescriptionChunk {
 }
 
 /// A SourceDescriptionItem is a part of a SourceDescription that describes a stream.
-#[derive(Debug, PartialEq, Default, Clone)]
+#[derive(Debug, PartialEq, Eq, Default, Clone)]
 pub struct SourceDescriptionItem {
     /// The type identifier for this item. eg, SDESCNAME for canonical name description.
     ///
@@ -274,7 +274,7 @@ impl Unmarshal for SourceDescriptionItem {
 }
 
 /// A SourceDescription (SDES) packet describes the sources in an RTP stream.
-#[derive(Debug, Default, PartialEq, Clone)]
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
 pub struct SourceDescription {
     pub chunks: Vec<SourceDescriptionChunk>,
 }

--- a/src/transport_feedbacks/rapid_resynchronization_request/mod.rs
+++ b/src/transport_feedbacks/rapid_resynchronization_request/mod.rs
@@ -15,7 +15,7 @@ const RRR_HEADER_LENGTH: usize = SSRC_LENGTH * 2;
 const RRR_MEDIA_OFFSET: usize = 4;
 
 /// The RapidResynchronizationRequest packet informs the encoder about the loss of an undefined amount of coded video data belonging to one or more pictures
-#[derive(Debug, PartialEq, Default, Clone)]
+#[derive(Debug, PartialEq, Eq, Default, Clone)]
 pub struct RapidResynchronizationRequest {
     /// SSRC of sender
     pub sender_ssrc: u32,

--- a/src/transport_feedbacks/transport_layer_cc/mod.rs
+++ b/src/transport_feedbacks/transport_layer_cc/mod.rs
@@ -39,7 +39,7 @@ type Result<T> = std::result::Result<T, util::Error>;
 
 // for packet status chunk
 /// type of packet status chunk
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 #[repr(u16)]
 pub enum StatusChunkTypeTcc {
     RunLengthChunk = 0,
@@ -47,7 +47,7 @@ pub enum StatusChunkTypeTcc {
 }
 
 /// type of packet status symbol and recv delta
-#[derive(PartialEq, Debug, Copy, Clone)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone)]
 #[repr(u16)]
 pub enum SymbolTypeTcc {
     /// https://tools.ietf.org/html/draft-holmer-rmcat-transport-wide-cc-extensions-01#section-3.1.1
@@ -62,7 +62,7 @@ pub enum SymbolTypeTcc {
 }
 
 /// for status vector chunk
-#[derive(PartialEq, Debug, Copy, Clone)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone)]
 #[repr(u16)]
 pub enum SymbolSizeTypeTcc {
     /// https://tools.ietf.org/html/draft-holmer-rmcat-transport-wide-cc-extensions-01#section-3.1.4
@@ -119,7 +119,7 @@ impl Default for SymbolTypeTcc {
 
 /// PacketStatusChunk has two kinds:
 /// RunLengthChunk and StatusVectorChunk
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PacketStatusChunk {
     RunLengthChunk(RunLengthChunk),
     StatusVectorChunk(StatusVectorChunk),
@@ -150,7 +150,7 @@ impl Marshal for PacketStatusChunk {
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// |T| S |       Run Length        |
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct RunLengthChunk {
     /// T = TypeTCCRunLengthChunk
     pub type_tcc: StatusChunkTypeTcc,
@@ -223,7 +223,7 @@ impl Unmarshal for RunLengthChunk {
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// |T|S|       symbol list         |
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct StatusVectorChunk {
     /// T = TypeTCCRunLengthChunk
     pub type_tcc: StatusChunkTypeTcc,
@@ -320,7 +320,7 @@ impl Unmarshal for StatusVectorChunk {
 /// small delta is 1 byte: [0，63.75]ms = [0, 63750]us = [0, 255]*250us
 /// big delta is 2 bytes: [-8192.0, 8191.75]ms = [-8192000, 8191750]us = [-32768, 32767]*250us
 /// https://tools.ietf.org/html/draft-holmer-rmcat-transport-wide-cc-extensions-01#section-3.1.5
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct RecvDelta {
     pub type_tcc_packet: SymbolTypeTcc,
     /// us
@@ -441,7 +441,7 @@ const PACKET_STATUS_CHUNK_LENGTH: usize = 2;
 
 /// TransportLayerCC for sender-BWE
 /// https://tools.ietf.org/html/draft-holmer-rmcat-transport-wide-cc-extensions-01#page-5
-#[derive(Debug, Default, PartialEq, Clone)]
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
 pub struct TransportLayerCc {
     /// SSRC of sender
     pub sender_ssrc: u32,

--- a/src/transport_feedbacks/transport_layer_nack/mod.rs
+++ b/src/transport_feedbacks/transport_layer_nack/mod.rs
@@ -16,7 +16,7 @@ type PacketBitmap = u16;
 
 /// NackPair is a wire-representation of a collection of
 /// Lost RTP packets
-#[derive(Debug, PartialEq, Default, Clone)]
+#[derive(Debug, PartialEq, Eq, Default, Clone)]
 pub struct NackPair {
     /// ID of lost packets
     pub packet_id: u16,
@@ -71,7 +71,7 @@ const NACK_OFFSET: usize = 8;
 // The TransportLayerNack packet informs the encoder about the loss of a transport packet
 // IETF RFC 4585, Section 6.2.1
 // https://tools.ietf.org/html/rfc4585#section-6.2.1
-#[derive(Debug, PartialEq, Default, Clone)]
+#[derive(Debug, PartialEq, Eq, Default, Clone)]
 pub struct TransportLayerNack {
     /// SSRC of sender
     pub sender_ssrc: u32,

--- a/src/util.rs
+++ b/src/util.rs
@@ -110,7 +110,7 @@ mod test {
             } else if let Ok(got) = res {
                 assert_eq!(got, result, "setNBitsOfUint16 {}", name);
             } else {
-                assert!(false, "setNBitsOfUint16 {} :unexpected error result", name);
+                panic!("setNBitsOfUint16 {} :unexpected error result", name);
             }
         }
 


### PR DESCRIPTION
rules:
- for crates that are below v1.0 -> specify the precise version
- If the code uses a feature that was added for example in X 0.3.17,
  then you should specify 0.3.17, which actually means "0.3.y where y >=
  17"
- for crates the are above or equal v1.0 -> specify only major version
  if the crate's API is minimal and won't change between minor versions
    OR specify major&minor versions otherwise

tested with https://github.com/taiki-e/cargo-minimal-versions