### PR TITLE
Prevent crash in RTCP NACK writing.

### DIFF
--- a/src/transport_feedbacks/transport_layer_nack/mod.rs
+++ b/src/transport_feedbacks/transport_layer_nack/mod.rs
@@ -226,10 +226,13 @@ pub fn nack_pairs_from_sequence_numbers(seq_nos: &[u16]) -> Vec<NackPair> {
 
     let mut pairs = vec![];
 
-    for seq in seq_nos.iter().skip(1) {
-        if seq - nack_pair.packet_id > 16 {
+    for &seq in seq_nos.iter().skip(1) {
+        if seq == nack_pair.packet_id {
+            continue;
+        }
+        if seq <= nack_pair.packet_id || seq - nack_pair.packet_id > 16 {
             pairs.push(nack_pair.clone());
-            nack_pair.packet_id = *seq;
+            nack_pair.packet_id = seq;
             continue;
         }
 

--- a/src/transport_feedbacks/transport_layer_nack/mod.rs
+++ b/src/transport_feedbacks/transport_layer_nack/mod.rs
@@ -230,12 +230,13 @@ pub fn nack_pairs_from_sequence_numbers(seq_nos: &[u16]) -> Vec<NackPair> {
         if seq == nack_pair.packet_id {
             continue;
         }
-        if seq <= nack_pair.packet_id || seq - nack_pair.packet_id > 16 {
+        if seq <= nack_pair.packet_id || seq > nack_pair.packet_id.saturating_add(16) {
             pairs.push(nack_pair.clone());
             nack_pair.packet_id = seq;
             continue;
         }
 
+        // Subtraction here is safe because the above checks that seqnum > nack_pair.packet_id.
         nack_pair.lost_packets |= 1 << (seq - nack_pair.packet_id - 1);
     }
 

--- a/src/transport_feedbacks/transport_layer_nack/transport_layer_nack_test.rs
+++ b/src/transport_feedbacks/transport_layer_nack/transport_layer_nack_test.rs
@@ -250,6 +250,15 @@ fn test_transport_layer_nack_pair_generation() {
                 lost_packets: 0x0,
             }],
         ),
+        // Make sure it doesn't crash.
+        (
+            "Single Sequence Number (duplicates)",
+            vec![100u16, 100],
+            vec![NackPair {
+                packet_id: 100,
+                lost_packets: 0x0,
+            }],
+        ),
         (
             "Multiple in range, Single NACKPair",
             vec![100, 101, 105, 115],
@@ -273,6 +282,50 @@ fn test_transport_layer_nack_pair_generation() {
                 NackPair {
                     packet_id: 500,
                     lost_packets: 0x3,
+                },
+            ],
+        ),
+        (
+            "Multiple Ranges, Multiple NACKPair",
+            vec![100, 117, 500, 501, 502],
+            vec![
+                NackPair {
+                    packet_id: 100,
+                    lost_packets: 0,
+                },
+                NackPair {
+                    packet_id: 117,
+                    lost_packets: 0,
+                },
+                NackPair {
+                    packet_id: 500,
+                    lost_packets: 0x3,
+                },
+            ],
+        ),
+        (
+            "Multiple Ranges, Multiple NACKPair (with rollover)",
+            vec![100, 117, 65535, 0, 1, 99],
+            vec![
+                NackPair {
+                    packet_id: 100,
+                    lost_packets: 0,
+                },
+                NackPair {
+                    packet_id: 117,
+                    lost_packets: 0,
+                },
+                NackPair {
+                    packet_id: 65535,
+                    lost_packets: 0,
+                },
+                NackPair {
+                    packet_id: 0,
+                    lost_packets: 1,
+                },
+                NackPair {
+                    packet_id: 99,
+                    lost_packets: 1,
                 },
             ],
         ),

--- a/src/transport_feedbacks/transport_layer_nack/transport_layer_nack_test.rs
+++ b/src/transport_feedbacks/transport_layer_nack/transport_layer_nack_test.rs
@@ -305,7 +305,7 @@ fn test_transport_layer_nack_pair_generation() {
         ),
         (
             "Multiple Ranges, Multiple NACKPair (with rollover)",
-            vec![100, 117, 65535, 0, 1, 99],
+            vec![100, 117, 65534, 65535, 0, 1, 99],
             vec![
                 NackPair {
                     packet_id: 100,
@@ -316,8 +316,8 @@ fn test_transport_layer_nack_pair_generation() {
                     lost_packets: 0,
                 },
                 NackPair {
-                    packet_id: 65535,
-                    lost_packets: 0,
+                    packet_id: 65534,
+                    lost_packets: 1,
                 },
                 NackPair {
                     packet_id: 0,


### PR DESCRIPTION
Seqnum rollover could cause the given seqnums to be out of order, which can cause an underflow on the subtraction.

And it's probably better not to crash if the caller provides duplicate seqnums.

An alternative approach would be to copy the slice into a Vec or require passing in a Vec and then sort the Vec before writing.  But that would be slower.

A better approach would be to make seqnums passed in be u64s so rollover isn't dealt with until writing out the packet (see, for example: https://github.com/signalapp/Signal-Calling-Service/blob/ae4365a13e5a4c64e47f3364620c4811dff004f5/src/rtp.rs#L1074).  But that would change the API and require changes in many places.  